### PR TITLE
Bump php-saml version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": "^7.2.0",
     "illuminate/config": ">=5.0",
     "illuminate/support": ">=5.0",
-    "onelogin/php-saml": "3.3.0",
+    "onelogin/php-saml": "3.4.1",
     "cweagans/composer-patches": "^1.6",
     "sensiolabs/security-checker": "^6.0"
   },
@@ -44,7 +44,7 @@
     },
     "patches": {
       "onelogin/php-saml": {
-        "Compatibility with SPID": "https://rawgit.com/italia/spid-laravel/master/patches/php-saml-3.3.0-spid.patch"
+        "Compatibility with SPID": "https://rawgit.com/italia/spid-laravel/php-saml-3.4.1/patches/php-saml-3.4.1-spid.patch"
       }
     }
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c30d9b69ecc7f5111f5cc9f7dcadffb2",
+    "content-hash": "c181f192ce478dace6bdf28bbe8e6bf7",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -810,21 +810,21 @@
         },
         {
             "name": "onelogin/php-saml",
-            "version": "3.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/onelogin/php-saml.git",
-                "reference": "a79a9e3cdd414ec177aad916ce741210052620c7"
+                "reference": "5fbf3486704ac9835b68184023ab54862c95f213"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/a79a9e3cdd414ec177aad916ce741210052620c7",
-                "reference": "a79a9e3cdd414ec177aad916ce741210052620c7",
+                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/5fbf3486704ac9835b68184023ab54862c95f213",
+                "reference": "5fbf3486704ac9835b68184023ab54862c95f213",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "robrichards/xmlseclibs": ">=3.0.3"
+                "robrichards/xmlseclibs": ">=3.0.4"
             },
             "require-dev": {
                 "pdepend/pdepend": "^2.5.0",
@@ -842,7 +842,7 @@
             "type": "library",
             "extra": {
                 "patches_applied": {
-                    "Compatibility with SPID": "https://rawgit.com/italia/spid-laravel/master/patches/php-saml-3.3.0-spid.patch"
+                    "Compatibility with SPID": "https://rawgit.com/italia/spid-laravel/php-saml-3.4.1/patches/php-saml-3.4.1-spid.patch"
                 }
             },
             "autoload": {
@@ -861,7 +861,7 @@
                 "onelogin",
                 "saml"
             ],
-            "time": "2019-09-11T13:56:06+00:00"
+            "time": "2019-11-25T17:30:07+00:00"
         },
         {
             "name": "opis/closure",

--- a/config/spid-saml.php
+++ b/config/spid-saml.php
@@ -57,6 +57,8 @@ return [
     'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
     'requestedAuthnContext' => [],
     'requestedAuthnContextComparison' => 'minimum',
+    'destinationStrictlyMatches' => true,
+    'rejectUnsolicitedResponsesWithInResponseTo' => true,
   ],
   'strict' => true,
 

--- a/patches/php-saml-3.4.1-spid.patch
+++ b/patches/php-saml-3.4.1-spid.patch
@@ -1,0 +1,87 @@
+diff --git a/src/Saml2/AuthnRequest.php b/src/Saml2/AuthnRequest.php
+index a1311f7..c498121 100644
+--- a/src/Saml2/AuthnRequest.php
++++ b/src/Saml2/AuthnRequest.php
+@@ -82,8 +82,7 @@ SUBJECT;
+             $nameIdPolicyStr = <<<NAMEIDPOLICY
+
+     <samlp:NameIDPolicy
+-        Format="{$nameIDPolicyFormat}"
+-        AllowCreate="true" />
++        Format="{$nameIDPolicyFormat}" />
+ NAMEIDPOLICY;
+         }
+
+@@ -156,12 +155,19 @@ REQUESTEDAUTHN;
+     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+     ID="$id"
+     Version="2.0"
+-{$providerNameStr}{$forceAuthnStr}{$isPassiveStr}
++{$forceAuthnStr}{$isPassiveStr}
+     IssueInstant="$issueInstant"
+-    Destination="{$idpData['singleSignOnService']['url']}"
++    Destination="{$idpData['entityId']}"
+     ProtocolBinding="{$spData['assertionConsumerService']['binding']}"
+-    AssertionConsumerServiceURL="{$acsUrl}">
+-    <saml:Issuer>{$spEntityId}</saml:Issuer>{$subjectStr}{$nameIdPolicyStr}{$requestedAuthnStr}
++    AssertionConsumerServiceURL="{$acsUrl}"
++    AttributeConsumingServiceIndex="0">
++    <saml:Issuer
++        NameQualifier="{$spEntityId}"
++        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">
++        {$spEntityId}
++    </saml:Issuer>
++{$nameIdPolicyStr}
++{$requestedAuthnStr}
+ </samlp:AuthnRequest>
+ AUTHNREQUEST;
+
+diff --git a/src/Saml2/LogoutRequest.php b/src/Saml2/LogoutRequest.php
+index d540c22..aa3c417 100644
+--- a/src/Saml2/LogoutRequest.php
++++ b/src/Saml2/LogoutRequest.php
+@@ -135,8 +135,12 @@ class LogoutRequest
+     ID="{$id}"
+     Version="2.0"
+     IssueInstant="{$issueInstant}"
+-    Destination="{$idpData['singleLogoutService']['url']}">
+-    <saml:Issuer>{$spEntityId}</saml:Issuer>
++    Destination="{$idpData['entityId']}">
++    <saml:Issuer
++        NameQualifier="{$spEntityId}"
++        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">
++        {$spEntityId}
++    </saml:Issuer>
+     {$nameIdObj}
+     {$sessionIndexStr}
+ </samlp:LogoutRequest>
+diff --git a/src/Saml2/Metadata.php b/src/Saml2/Metadata.php
+index 922ad60..d00b705 100644
+--- a/src/Saml2/Metadata.php
++++ b/src/Saml2/Metadata.php
+@@ -163,7 +163,7 @@ ATTRIBUTEVALUE;
+
+             $requestedAttributeStr = implode(PHP_EOL, $requestedAttributeData);
+             $strAttributeConsumingService = <<<METADATA_TEMPLATE
+-<md:AttributeConsumingService index="1">
++<md:AttributeConsumingService index="0">
+             <md:ServiceName xml:lang="en">{$sp['attributeConsumingService']['serviceName']}</md:ServiceName>
+ {$attrCsDesc}{$requestedAttributeStr}
+         </md:AttributeConsumingService>
+@@ -175,14 +175,13 @@ METADATA_TEMPLATE;
+         $metadata = <<<METADATA_TEMPLATE
+ <?xml version="1.0"?>
+ <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+-                     validUntil="{$validUntilTime}"
+-                     cacheDuration="PT{$cacheDuration}S"
+                      entityID="{$spEntityId}">
+     <md:SPSSODescriptor AuthnRequestsSigned="{$strAuthnsign}" WantAssertionsSigned="{$strWsign}" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+ {$sls}        <md:NameIDFormat>{$sp['NameIDFormat']}</md:NameIDFormat>
+         <md:AssertionConsumerService Binding="{$sp['assertionConsumerService']['binding']}"
+                                      Location="{$acsUrl}"
+-                                     index="1" />
++                                     isDefault="true"
++                                     index="0" />
+         {$strAttributeConsumingService}
+     </md:SPSSODescriptor>{$strOrganization}{$strContacts}
+ </md:EntityDescriptor>


### PR DESCRIPTION
Bump php-saml version to 3.4.1 which fixes vulnerability of xmlseclibs dependency.