### PR TITLE
#51 Registro Delle Transazioni (WIP)

### DIFF
--- a/src/Events/LoggerEvent.php
+++ b/src/Events/LoggerEvent.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This class implements a Laravel Event for SPIDAuth Package.
+ *
+ * @license BSD-3-clause
+ */
+
+namespace Italia\SPIDAuth\Events;
+
+use Italia\SPIDAuth\SPIDLogger;
+
+class LoggerEvent
+{
+    /** The current selected Identity Provider. */
+    protected $idp;
+
+    /** The SPIDLogger with current event data. */
+    protected $SPIDLogger;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param SPIDLogger current log data
+     * @param string current selected Identity Provider
+     */
+    public function __construct(string $idp, SPIDLogger $SPIDLogger)
+    {
+        $this->idp = $idp;
+        $this->SPIDLogger = $SPIDLogger;
+    }
+
+    /**
+     * Return idp.
+     *
+     * @return string Identity Provider used to login
+     */
+    public function getIdp(): string
+    {
+        return $this->idp;
+    }
+
+    /**
+     * Return SPIDLogger.
+     *
+     * @return SPIDLogger current log data
+     */
+    public function getSPIDLogger(): SPIDLogger
+    {
+        return $this->SPIDLogger;
+    }
+}

--- a/src/SPIDLogger.php
+++ b/src/SPIDLogger.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * This class implements a SPIDUser for SPIDAuth Package.
+ *
+ * @license BSD-3-clause
+ */
+
+namespace Italia\SPIDAuth;
+
+class SPIDLogger
+{
+    /**
+     * Action type. Can be either LOGIN or LOGOUT.
+     * @var string
+     */
+    protected $action;
+
+    /**
+     * @var string
+     */
+    protected $requestId;
+
+    /**
+     * @var string
+     */
+    protected $requestIssueInstant;
+
+    /**
+     * @var string
+     */
+    protected $requestXML;
+
+    /**
+     * @var string
+     */
+    protected $responseId;
+
+    /**
+     * @var string
+     */
+    protected $responseIssueInstant;
+
+    /**
+     * @var string
+     */
+    protected $responseXML;
+
+    /**
+     * @var string
+     */
+    protected $assertionId;
+
+    /**
+     * @var string
+     */
+    protected $assertionNameId;
+
+    /**
+     * @var string
+     */
+    protected $assertionNameIdNameQualifier;
+
+    /**
+     * @var string
+     */
+    protected $error;
+
+
+    /**
+     * SPIDLogger constructor.
+     *
+     * @param string $action
+     * @param string $requestId
+     */
+    public function __construct(string $action, string $requestId)
+    {
+        $this->action = $action;
+        $this->requestId = $requestId;
+    }
+
+    /**
+     * Set request data.
+     *
+     * @param string $requestIssueInstant
+     * @param string $requestXML
+     */
+    public function setRequestData(string $requestIssueInstant, string $requestXML)
+    {
+        $this->requestIssueInstant = $requestIssueInstant;
+        $this->requestXML = $requestXML;
+    }
+
+    /**
+     * Set response data.
+     *
+     * @param string|null $responseId
+     * @param string|null $responseXML
+     * @param string|null $responseIssueInstant
+     * @param string|null $assertionId
+     * @param string|null $assertionNameId
+     * @param string|null $assertionNameIdNameQualifier
+     */
+    public function setResponseData(
+        ?string $responseId,
+        ?string $responseXML,
+        ?string $responseIssueInstant,
+        ?string $assertionId = null,
+        ?string $assertionNameId = null,
+        ?string $assertionNameIdNameQualifier = null) {
+
+        $this->responseId = $responseId;
+        $this->responseXML = $responseXML;
+        $this->responseIssueInstant = $responseIssueInstant;
+        $this->assertionId = $assertionId;
+        $this->assertionNameId = $assertionNameId;
+        $this->assertionNameIdNameQualifier = $assertionNameIdNameQualifier;
+    }
+
+    /**
+     * Set error data.
+     *
+     * @param string $error
+     */
+    public function setErrorData(string $error)
+    {
+        $this->error = $error;
+    }
+
+
+    /**
+     * Get action parameter.
+     *
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * Get requestId parameter.
+     *
+     * @return string
+     */
+    public function getRequestId()
+    {
+        return $this->requestId;
+    }
+
+    /**
+     * Get requestIssueInstant parameter.
+     *
+     * @return string
+     */
+    public function getRequestIssueInstant()
+    {
+        return $this->requestIssueInstant;
+    }
+
+    /**
+     * Get requestXML parameter.
+     *
+     * @return string
+     */
+    public function getRequestXML()
+    {
+        return $this->requestXML;
+    }
+
+    /**
+     * Get responseId parameter.
+     *
+     * @return string
+     */
+    public function getResponseId()
+    {
+        return $this->responseId;
+    }
+
+    /**
+     * Get responseXML parameter.
+     *
+     * @return string
+     */
+    public function getResponseXML()
+    {
+        return $this->responseXML;
+    }
+
+    /**
+     * Get responseIssueInstant parameter.
+     *
+     * @return string
+     */
+    public function getResponseIssueInstant()
+    {
+        return $this->responseIssueInstant;
+    }
+
+    /**
+     * Get assertionId parameter.
+     *
+     * @return string
+     */
+    public function getAssertionId()
+    {
+        return $this->assertionId;
+    }
+
+    /**
+     * Get assertionNameId parameter.
+     *
+     * @return string
+     */
+    public function getAssertionNameId()
+    {
+        return $this->assertionNameId;
+    }
+
+    /**
+     * Get assertionNameIdNameQualifier parameter.
+     *
+     * @return string
+     */
+    public function getAssertionNameIdNameQualifier()
+    {
+        return $this->assertionNameIdNameQualifier;
+    }
+
+    /**
+     * Get error parameter.
+     *
+     * @return string
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}


### PR DESCRIPTION
Posting this to gather feedback.
Added LoggerEvent and handling.

LoggerEvent può essere usato per scrivere dati di log in una tabella del database.
Al momento questo è quello che sto usando:
```
create table spid_entries
(
    id                               bigint unsigned auto_increment
        primary key,
    uuid                             char(36)     not null,
    action                           varchar(255) null,
    request_id                       varchar(255) null,
    request_issue_instant            varchar(255) null,
    request_xml                      text         null,
    response_id                      varchar(255) null,
    response_issue_instant           varchar(255) null,
    response_xml                     text         null,
    assertion_id                     varchar(255) null,
    assertion_name_id                varchar(255) null,
    assertion_name_id_name_qualifier varchar(255) null,
    error                            text         null,
    created_at                       timestamp    null,
    updated_at                       timestamp    null,
    constraint spid_entries_uuid_unique
        unique (uuid)
)
    collate = utf8mb4_unicode_ci;

create index spid_entries_action_index
    on spid_entries (action);

create index spid_entries_action_request_id_index
    on spid_entries (action, request_id);

create index spid_entries_assertion_id_index
    on spid_entries (assertion_id);

create index spid_entries_request_id_index
    on spid_entries (request_id);
```

Ancora non ho aggiornato ne documentazione, ne eventuali tests.
Vorrei sapere che ne pensate, e se siete interessati a mergiare una cosa simile.

Grazie mille, 
Ivan