### PR TITLE
Add SAML2 ProxyVars configuration setting

### DIFF
--- a/config/spid-auth.php
+++ b/config/spid-auth.php
@@ -101,4 +101,6 @@ return [
     'login_view' => 'spid-auth::login-spid',
     'after_login_url' => '/',
     'after_logout_url' => '/',
+
+    'saml_proxy_vars' => false,
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -43,7 +43,6 @@ class ServiceProvider extends LaravelServiceProvider
         if ($proxyVars) {
             SAMLUtils::setProxyVars($proxyVars);
         }
-
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,6 +10,7 @@ namespace Italia\SPIDAuth;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
+use OneLogin\Saml2\Utils as SAMLUtils;
 
 class ServiceProvider extends LaravelServiceProvider
 {
@@ -37,6 +38,12 @@ class ServiceProvider extends LaravelServiceProvider
         $router->aliasMiddleware('spid.auth', \Italia\SPIDAuth\Middleware::class);
 
         View::share('SPIDActionUrl', route('spid-auth_do-login'));
+
+        $proxyVars = config('spid-auth.saml_proxy_vars');
+        if ($proxyVars) {
+            SAMLUtils::setProxyVars($proxyVars);
+        }
+
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/italia/spid-laravel/issues/39

Now we have following variable into `spid-auth.php` file to configure proxyVars value:
```
...
'saml_proxy_vars' => false,
...
```