### PR TITLE
fix: composer patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "patches": {
       "onelogin/php-saml": {
-        "Compatibility with SPID": "https://rawgit.com/italia/spid-laravel/master/patches/php-saml-4.1.0-spid.patch"
+        "Compatibility with SPID": "./patches/php-saml-4.1.0-spid.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "patches": {
       "onelogin/php-saml": {
-        "Compatibility with SPID": "./patches/php-saml-4.1.0-spid.patch"
+        "Compatibility with SPID": "https://raw.githubusercontent.com/italia/spid-laravel/refs/heads/master/patches/php-saml-4.1.0-spid.patch"
       }
     }
   },


### PR DESCRIPTION
Fixes issue #121 by replacing the dead `rawgit.com` URL with the GitHub raw content URL for the php-saml patch.